### PR TITLE
Add supervisor script to handle startup and checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,6 @@ ADD https://bintray.com/artifact/download/lmineiro/maven/cassandra-etcd-seed-pro
 # ADD cassandra-etcd-seed-provider-1.0.jar /opt/cassandra/lib/
 
 COPY stups-cassandra.sh /opt/cassandra/bin/
-CMD /opt/cassandra/bin/stups-cassandra.sh
+COPY supervisor.sh /opt/cassandra/bin/
+
+CMD /opt/cassandra/bin/supervisor.sh

--- a/stups-cassandra.sh
+++ b/stups-cassandra.sh
@@ -3,107 +3,18 @@
 # DATA_DIR
 # COMMIT_LOG_DIR
 # LISTEN_ADDRESS
-
-# http://docs.datastax.com/en/cassandra/2.0/cassandra/architecture/architectureGossipAbout_c.html
-# "...it is recommended to use a small seed list (approximately three nodes per data center)."
-NEEDED_SEEDS=$((CLUSTER_SIZE > 3 ? 3 : 1))
-TTL=${TTL:-30}
-
-if [ -z "$ETCD_URL" ] ;
-then
-    echo "etcd URL is not defined."
-    exit 1
-fi
-echo "Using $ETCD_URL to access etcd ..."
-
-if [ -z "$CLUSTER_NAME" ] ;
-then
-    echo "Cluster name is not defined."
-    exit 1
-fi
-
-# TODO: use public-ipv4 if multi-region
-if [ -z "$LISTEN_ADDRESS" ] ;
-then
-    export LISTEN_ADDRESS=$(curl -Ls -m 4 http://169.254.169.254/latest/meta-data/local-ipv4)
-fi
-echo "Node IP address is $LISTEN_ADDRESS ..."
-
-# TODO: Use diff. Snitch if Multi-Region
-if [ -z $SNITCH ] ;
-then
-    export SNITCH="Ec2Snitch"
-fi
-
-if [ -z "$OPSCENTER" ] ;
-then
-    export OPSCENTER=$(curl -Ls -m 4 ${ETCD_URL}/v2/keys/cassandra/opscenter | jq -r '.node.value')
-fi
      
 export DATA_DIR=${DATA_DIR:-/var/cassandra/data}
 export COMMIT_LOG_DIR=${COMMIT_LOG_DIR:-/var/cassandra/data/commit_logs}
-            
-curl -s "${ETCD_URL}/v2/keys/cassandra/${CLUSTER_NAME}/size?prevExist=false" \
-    -XPUT -d value=${CLUSTER_SIZE} > /dev/null
-
-while true; do 
-    curl -Lsf "${ETCD_URL}/v2/keys/cassandra/${CLUSTER_NAME}/_bootstrap?prevExist=false" \
-        -XPUT -d value=${LISTEN_ADDRESS} -d ttl=${TTL} > /dev/null
-    if [ $? -eq 0 ] ;
-    then
-        echo "Acquired bootstrap lock. Setting up node ..."
-        SEED_COUNT=$(curl -Ls ${ETCD_URL}/v2/keys/cassandra/${CLUSTER_NAME}/seeds | jq '.node.nodes | length')
-        if [ $SEED_COUNT -lt $NEEDED_SEEDS ] ;
-        then
-            echo "Registering node as seed ..."
-            curl -Lsf "${ETCD_URL}/v2/keys/cassandra/${CLUSTER_NAME}/seeds" \
-                -XPOST -d value=${LISTEN_ADDRESS} > /dev/null
-        fi
-
-        # Register the cluster with OpsCenter if there's already at least 1 seed node
-        if [ -n $OPSCENTER -a $SEED_COUNT -gt 0 ] ;
-        then
-            curl -Lsf "${ETCD_URL}/v2/keys/cassandra/${CLUSTER_NAME}/opscenter_ip?prevExist=false" \
-                -XPUT -d value=${OPSCENTER} > /dev/null
-            if [ $? -eq 0 ] ;
-            then
-                # First seed node is fine, it should allow opscenter to discover the rest
-                SEED=$(curl -sL ${ETCD_URL}/v2/keys/cassandra/${CLUSTER_NAME}/seeds | \
-                    jq -r '.node.nodes[0].value')
-                echo "Registering cluster with OpsCenter $OPSCENTER using seed $SEED ..."
-                PAYLOAD="{\"cassandra\":{\"seed_hosts\":\"$SEED\"},\"cassandra_metrics\":{},\"jmx\":{\"port\":\"7199\"}}"
-                curl -ksL http://${OPSCENTER}:8888/cluster-configs -X POST -d $PAYLOAD > /dev/null
-            fi
-        fi
-
-        break
-    else
-        echo "Failed to acquire boostrap lock. Waiting for 5 seconds ..."
-        sleep 5
-    fi
-done
-
-echo "Finished bootstrapping node."
-# Add route 53record seed1.${CLUSTER_NAME}.domain.tld ?
-
-if [ -n "$OPSCENTER" ] ;
-then
-    echo "Configuring OpsCenter agent ..."
-    echo "stomp_interface: $OPSCENTER" >> /var/lib/datastax-agent/conf/address.yaml
-    echo "hosts: [\"$LISTEN_ADDRESS\"]" >> /var/lib/datastax-agent/conf/address.yaml
-    echo "cassandra_conf: /opt/cassandra/conf/cassandra.yaml" >> /var/lib/datastax-agent/conf/address.yaml
-    echo "Starting OpsCenter agent in the background ..."
-    service datastax-agent start > /dev/null
-fi
 
 echo "Generating configuration from template ..."
-python -c "import os; print os.path.expandvars(open('/opt/cassandra/conf/cassandra_template.yaml').read())" > /opt/cassandra/conf/cassandra.yaml
-#python -c "import pystache, os; print(pystache.render(open('/opt/cassandra/conf/cassandra_template.yaml').read(), dict(os.environ)))" > /opt/cassandra/conf/cassandra.yaml
-
+python -c "import os; print os.path.expandvars(open('${CASSANDRA_HOME}/conf/cassandra_template.yaml').read())" > ${CASSANDRA_HOME}/conf/cassandra.yaml
+#python -c "import pystache, os; print(pystache.render(open('${CASSANDRA_HOME}/conf/cassandra_template.yaml').read(), dict(os.environ)))" > ${CASSANDRA_HOME}/conf/cassandra.yaml
 
 echo "Starting Cassandra ..."
-/opt/cassandra/bin/cassandra -f \
+${CASSANDRA_HOME}/bin/cassandra -f \
     -Dcassandra.logdir=/var/cassandra/log \
     -Dcassandra.cluster_name=${CLUSTER_NAME} \
     -Dcassandra.listen_address=${LISTEN_ADDRESS} \
-    -Dcassandra.broadcast_rpc_address=${LISTEN_ADDRESS}
+    -Dcassandra.broadcast_rpc_address=${LISTEN_ADDRESS} \
+    $*

--- a/supervisor.sh
+++ b/supervisor.sh
@@ -104,6 +104,7 @@ while true; do
         else
             echo "There are already some seed nodes ..."
 
+            seed_reached=false
             for seed in $SEEDS; do
                 echo "Querying a seed node ${seed} for the cluster status ..."
                 if nodetool -h $seed status >/tmp/nodetool-remote-status ;
@@ -115,6 +116,7 @@ while true; do
                         REPLACE_ADDRESS_PARAM=-Dcassandra.replace_address=${DEAD_NODE_ADDRESS}
                     fi
                     # we've reached one seed, no point to keep trying
+                    seed_reached=true
                     break
                 else
                     # This might be a seed from an earlier incarnation of this
@@ -126,6 +128,12 @@ while true; do
                     curl -Lsf "${ETCD_OPSCENTER_URL}?recursive=true" -XDELETE > /dev/null
                 fi
             done
+
+            if [ $seed_reached = false ] ;
+            then
+                echo "No seeds could be reached ..."
+                register_as_seed
+            fi
         fi
         break
     else

--- a/supervisor.sh
+++ b/supervisor.sh
@@ -1,0 +1,211 @@
+#!/bin/sh
+#
+# This is a supervisor script that handles things we need to do before
+# starting the cassandra process and continious monitoring after that.
+#
+TTL=${TTL:-30}
+SLEEP_INTERVAL=${SLEEP_INTERVAL:-60}
+
+if [ -z "$ETCD_URL" ] ;
+then
+    echo "etcd URL is not defined."
+    exit 1
+fi
+echo "Using $ETCD_URL to access etcd ..."
+
+if [ -z "$CLUSTER_NAME" ] ;
+then
+    echo "Cluster name is not defined."
+    exit 1
+fi
+
+EC2_META_URL=http://169.254.169.254/latest/meta-data
+
+# TODO: use public-* if multi-region
+export LISTEN_ADDRESS=$(curl -s ${EC2_META_URL}/local-ipv4)
+NODE_HOSTNAME=$(curl -s ${EC2_META_URL}/local-hostname)
+NODE_ZONE=$(curl -s ${EC2_META_URL}/placement/availability-zone)
+echo "Node IP address is $LISTEN_ADDRESS ..."
+echo "Node hostname is $NODE_HOSTNAME ..."
+echo "Node availability zone is $NODE_ZONE ..."
+
+curl -s "${ETCD_URL}/v2/keys/cassandra/${CLUSTER_NAME}/size?prevExist=false" \
+    -XPUT -d value=${CLUSTER_SIZE} > /dev/null
+
+SEEDS_URL="${ETCD_URL}/v2/keys/cassandra/${CLUSTER_NAME}/seeds"
+ETCD_OPSCENTER_URL="${ETCD_URL}/v2/keys/cassandra/${CLUSTER_NAME}/opscenter"
+
+# Add route 53record seed1.${CLUSTER_NAME}.domain.tld ?
+
+# for the nodetool
+export CASSANDRA_HOME=/opt/cassandra
+export CASSANDRA_INCLUDE=${CASSANDRA_HOME}/bin/cassandra.in.sh
+
+query_seeds() {
+    curl -sL "${SEEDS_URL}" | jq -r '.node.nodes[].value' | \
+        while read data; do \
+            echo $data | jq -r '.host'; \
+        done
+}
+
+register_in_opscenter() {
+    STOMP_INTERFACE=$(echo $OPSCENTER | awk -F/ '{print $3}')
+    echo "Configuring OpsCenter agent with stopm_interface $STOMP_INTERFACE ..."
+    echo "stomp_interface: $STOMP_INTERFACE" | tee -a /var/lib/datastax-agent/conf/address.yaml
+
+    echo "Starting OpsCenter agent in the background ..."
+    service datastax-agent start
+
+    SEEDS=$(echo $(query_seeds) | tr \  ,)
+    echo "Registering cluster with OpsCenter using seeds $SEEDS ..."
+    curl ${OPSCENTER}/cluster-configs -X POST \
+         -d "{
+               \"cassandra\": {
+                 \"seed_hosts\": \"$SEEDS\"
+               },
+               \"cassandra_metrics\": {},
+               \"jmx\": {
+                 \"port\": \"7199\"
+               }
+             }" > /dev/null
+}
+
+bootstrap_lock() {
+    echo "Trying to acquire bootstrap lock ..."
+    curl -Lsf "${ETCD_URL}/v2/keys/cassandra/${CLUSTER_NAME}/_bootstrap?prevExist=false" \
+         -XPUT -d value=${LISTEN_ADDRESS} -d ttl=${TTL} > /dev/null
+}
+
+register_as_seed() {
+    echo "Registering this node as the seed for zone ${NODE_ZONE} ..."
+    curl -Lsf "${SEEDS_URL}/${NODE_HOSTNAME}" \
+         -XPUT -d value="{\"host\":\"${LISTEN_ADDRESS}\",\"availabilityZone\":\"${NODE_ZONE}\"}" > /dev/null
+}
+
+remove_stale_seed() {
+    node=$1
+    echo "Removing stale seed entry: $node ..."
+    curl -Lsf "${SEEDS_URL}/${node}" -XDELETE > /dev/null
+}
+
+REPLACE_ADDRESS_PARAM=''
+
+# for the very first node, we have to declare itself a seed before starting Cassandra up
+while true; do
+    if bootstrap_lock ;
+    then
+        echo "Acquired bootstrap lock."
+
+        SEEDS=$(query_seeds)
+        if [ -z "$SEEDS" ] ;
+        then
+            echo "No seed nodes yet, assuming fresh cluster start ..."
+            register_as_seed
+        else
+            echo "There are already some seed nodes ..."
+
+            for seed in $SEEDS; do
+                echo "Querying a seed node ${seed} for the cluster status ..."
+                if nodetool -h $seed status >/tmp/nodetool-remote-status ;
+                then
+                    DEAD_NODE_ADDRESS=$(grep '^D. ' </tmp/nodetool-remote-status | awk '{print $2; exit}')
+                    if [ -n "$DEAD_NODE_ADDRESS" ] ;
+                    then
+                        echo "There was a dead node at ${DEAD_NODE_ADDRESS}, will try to replace it ..."
+                        REPLACE_ADDRESS_PARAM=-Dcassandra.replace_address=${DEAD_NODE_ADDRESS}
+                    fi
+                    # we've reached one seed, no point to keep trying
+                    break
+                else
+                    # This might be a seed from an earlier incarnation of this
+                    # cluster *with the same version.*  We have to remove it,
+                    # otherwise cassandra won't be able to start at all.
+                    remove_stale_seed $seed
+
+                    # And also remove earlier OpsCenter registration key if any.
+                    curl -Lsf "${ETCD_OPSCENTER_URL}?recursive=true" -XDELETE > /dev/null
+                fi
+            done
+        fi
+        break
+    else
+        echo "Failed to acquire bootstrap lock. Waiting for 5 seconds ..."
+        sleep 5
+    fi
+done
+
+./stups-cassandra.sh ${REPLACE_ADDRESS_PARAM} &
+
+# wake up every so often to check the node's status and the current seeds list
+while true; do
+    echo "Checking Boot status ..."
+    BOOT_STATUS=$(nodetool netstats | grep '^Mode: ' | awk '{print $2}')
+
+    echo "Boot status is $BOOT_STATUS ..."
+    if [ "${BOOT_STATUS}" = NORMAL ] ;
+    then
+        # first check for any stale seed entries and remove them
+        curl -sL "${ETCD_URL}/v2/keys/taupage" \
+            | jq -r '.node.nodes[].key' | awk -F/ '{print $3}' | \
+            sort >/tmp/stups-all-host-names
+
+        curl -sL "${SEEDS_URL}" \
+            | jq -r '.node.nodes[].key' | awk -F/ '{print $5}' | \
+            sort >/tmp/stups-cassandra-seed-names
+
+        echo "The list of all hosts as currently set by taupage: " \
+             $(tr \\n \  </tmp/stups-all-host-names)
+        echo "The list of seeds as currently known by etcd: " \
+             $(tr \\n \  </tmp/stups-cassandra-seed-names)
+
+        STALE_SEED_NAMES=$(diff --old-line-format= \
+                                --new-line-format=%L \
+                                --unchanged-group-format= \
+                                /tmp/stups-all-host-names \
+                                /tmp/stups-cassandra-seed-names)
+
+        for node in $STALE_SEED_NAMES; do
+            remove_stale_seed $node
+        done
+
+        # Now see if we don't have a seed in our availability zone (yet or anymore);
+        # if that's the case, try to become one.
+        while true; do
+            echo "Checking seeds availability zones ..."
+
+            curl -sL "${SEEDS_URL}" | jq -r '.node.nodes[].value' | \
+                while read data; do \
+                    echo $data | jq -r '.availabilityZone'; \
+                done | \
+                grep "^${NODE_ZONE}\$" >/dev/null
+            if [ $? -ne 0 ] ;
+            then
+                echo "No seed node found in availability zone ${NODE_ZONE} ..."
+                if bootstrap_lock ;
+                then
+                    register_as_seed
+                    break
+                else
+                    echo "Failed to acquire bootstrap lock. Waiting for 5 seconds ..."
+                    sleep 5
+                fi
+            else
+                echo "There is already a seed in availability zone ${NODE_ZONE} ..."
+                if [ -n "$OPSCENTER" ] ;
+                then
+                    # check if it's the first time
+                    curl -Lsf "${ETCD_OPSCENTER_URL}?prevExist=false" \
+                         -XPUT -d value=${OPSCENTER} > /dev/null
+                    if [ $? -eq 0 ] ;
+                    then
+                        register_in_opscenter
+                    fi
+                fi
+                break
+            fi
+        done
+    fi
+
+    echo "Sleeping ..."
+    sleep ${SLEEP_INTERVAL}
+done


### PR DESCRIPTION
This adds a supervisor script with the intent to handle all the corner cases
for cleaning up the seeds list that is entered in etcd as well as checking the
running cassandra instances and taking role of a failed seed when there is a
need for that (no seed in this node's availability zone).