### PR TITLE
Update Docker base image and Cassandra version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8u77-b03-1-20
+FROM registry.opensource.zalan.do/stups/openjdk:8u91-b14-1-22
 
 MAINTAINER Zalando <team-mop@zalando.de>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zalando/openjdk:8u45-b14-3
+FROM registry.opensource.zalan.do/stups/openjdk:8u77-b03-1-20
 
 MAINTAINER Zalando <team-mop@zalando.de>
 
@@ -10,14 +10,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN echo "deb http://debian.datastax.com/community stable main" | tee -a /etc/apt/sources.list.d/datastax.community.list
 RUN curl -sL https://debian.datastax.com/debian/repo_key | apt-key add -
 RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
-RUN apt-get -y install curl python wget jq datastax-agent sysstat python-pip supervisor && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get -y install curl python wget jq sudo datastax-agent sysstat python-pip supervisor && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Needed for transferring snapshots
 RUN pip install awscli
 
-ENV CASSIE_VERSION=2.2.4
+ENV CASSIE_VERSION=2.2.6
 ADD http://ftp.halifax.rwth-aachen.de/apache/cassandra/${CASSIE_VERSION}/apache-cassandra-${CASSIE_VERSION}-bin.tar.gz /tmp/
-RUN echo "cb77a8e3792a7e8551af6602ac5f11df /tmp/apache-cassandra-${CASSIE_VERSION}-bin.tar.gz" > /tmp/apache-cassandra-${CASSIE_VERSION}-bin.tar.gz.md5
+RUN echo "8e2a8696ced6c4f9db06c40b2f5a7936 /tmp/apache-cassandra-${CASSIE_VERSION}-bin.tar.gz" > /tmp/apache-cassandra-${CASSIE_VERSION}-bin.tar.gz.md5
 RUN md5sum --check /tmp/apache-cassandra-${CASSIE_VERSION}-bin.tar.gz.md5
 
 RUN tar -xzf /tmp/apache-cassandra-${CASSIE_VERSION}-bin.tar.gz -C /opt && ln -s /opt/apache-cassandra-${CASSIE_VERSION} /opt/cassandra


### PR DESCRIPTION
* Docker base image needs to refer to opensource registry (old one being
  removed recently).
* Installation of datastax-agent depends on /etc/sudoers being present,
  but sudo is not installed in base image.
* Cassandra-2.2.4 no longer available from the mirror site, use the
  latest version 2.2.6.